### PR TITLE
Fixes #27 : color logging is based on maven configuration

### DIFF
--- a/utplsql-maven-plugin/src/main/java/org/utplsql/maven/plugin/UtPLSQLMojo.java
+++ b/utplsql-maven-plugin/src/main/java/org/utplsql/maven/plugin/UtPLSQLMojo.java
@@ -16,6 +16,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.utplsql.api.DBHelper;
 import org.utplsql.api.FileMapperOptions;
 import org.utplsql.api.JavaApiVersionInfo;
@@ -61,14 +62,14 @@ public class UtPLSQLMojo extends AbstractMojo {
 	protected boolean skipCompatibilityCheck;
 
 	@Parameter
-	protected List<ReporterParameter> reporters = new ArrayList<ReporterParameter>();
+	protected List<ReporterParameter> reporters = new ArrayList<>();
 
 	@Parameter
-	protected List<String> paths = new ArrayList<String>();
+	protected List<String> paths = new ArrayList<>();
 
 	// Sources Configuration
 	@Parameter
-	protected List<Resource> sources = new ArrayList<Resource>();
+	protected List<Resource> sources = new ArrayList<>();
 
 	@Parameter
 	private String sourcesOwner;
@@ -117,8 +118,8 @@ public class UtPLSQLMojo extends AbstractMojo {
 	@Parameter(defaultValue = "${maven.test.failure.ignore}")
 	protected boolean ignoreFailure;
 
-	// Color in the console, loaded by environment variables
-	private boolean colorConsole = PluginDefault.resolveColor();
+	// Color in the console, bases on maven logging configuration
+	private boolean colorConsole = MessageUtils.isColorEnabled();
 
 	// Reporter Writer
 	private ReporterWriter reporterWriter;

--- a/utplsql-maven-plugin/src/main/java/org/utplsql/maven/plugin/helper/PluginDefault.java
+++ b/utplsql-maven-plugin/src/main/java/org/utplsql/maven/plugin/helper/PluginDefault.java
@@ -1,8 +1,6 @@
 package org.utplsql.maven.plugin.helper;
 
-import java.io.File;
 import java.util.Arrays;
-import java.util.Map;
 
 import org.apache.maven.model.Resource;
 
@@ -14,13 +12,6 @@ import org.apache.maven.model.Resource;
  */
 public class PluginDefault
 {
-
-	private static final String STYLE_COLOR_PROPERTY = "style.color";
-
-	private static final String BATCH_MODE = "B";
-
-	private static final String LOG_FILE = "l";
-
 	// Source Directory
 	public static final String SOURCE_DIRECTORY = "src/main/plsql";
 
@@ -69,32 +60,4 @@ public class PluginDefault
 		resource.setIncludes(Arrays.asList(includes));
 		return resource;
 	}
-
-	/**
-	 * 
-	 * @return
-	 */
-	public static boolean resolveColor()
-	{
-		final Map<String, String> env = System.getenv();
-		String color = env.get(STYLE_COLOR_PROPERTY);
-
-		if ("always".equals(color))
-		{
-			return true;
-		}
-
-		if ("never".equals(color))
-		{
-			return false;
-		}
-
-		if (env.containsKey(BATCH_MODE) || env.containsKey(LOG_FILE))
-		{
-			return false;
-		}
-
-		return false;
-	}
-
 }


### PR DESCRIPTION
-B (batchmode) and -l <filename> (output to file) removes coloration
-Dstyle.color=never removes coloration

Note: style.color seems to require at least maven 3.5.3