### PR TITLE
Embedded the java-api into the plugin jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ target/
 .mvn
 log.txt
 **/pom.xml.versionsBackup
+dependency-reduced-pom.xml
 
 # Docs
 doc/

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.utplsql</groupId>
     <artifactId>utplsql-maven-plugin</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.1.3-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>utPLSQL Maven Plugin</name>
@@ -49,9 +49,22 @@
         <maven.version>3.5.0</maven.version>
         <java.version>1.8</java.version>
         <powermock.version>1.7.4</powermock.version>
+        <ojdbc.version>12.2.0.1</ojdbc.version>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>orai18n</artifactId>
+            <version>${ojdbc.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.utplsql</groupId>
             <artifactId>java-api</artifactId>
@@ -143,6 +156,26 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>org.utplsql:java-api</include>
+                        </includes>
+                    </artifactSet>
                 </configuration>
             </plugin>
             <plugin>
@@ -327,5 +360,24 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+
+        <repository>
+            <id>maven.oracle.com</id>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <url>https://maven.oracle.com</url>
+            <layout>default</layout>
+        </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>maven.oracle.com</id>
+            <url>https://maven.oracle.com</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
The generated artifact will have java-api code embedded and it won't be part of the final pom for the library, that way the users won't need to add the java-api to their private repos.
I also added ojdbc as a direct dependency, but I'm not sure if this will fix #23 as I couldn't test it locally.