### PR TITLE
Swap DriverManager for DataSource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.utplsql</groupId>
     <artifactId>utplsql-maven-plugin</artifactId>
-    <version>3.1.2-SNAPSHOT</version>
+    <version>3.1.3-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>utPLSQL Maven Plugin</name>

--- a/src/main/java/org/utplsql/maven/plugin/UtPLSQLMojo.java
+++ b/src/main/java/org/utplsql/maven/plugin/UtPLSQLMojo.java
@@ -2,11 +2,10 @@ package org.utplsql.maven.plugin;
 
 import java.io.File;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-
+import oracle.jdbc.pool.OracleDataSource;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
@@ -135,8 +134,11 @@ public class UtPLSQLMojo extends AbstractMojo {
         try {
             FileMapperOptions sourceMappingOptions = buildSourcesOptions();
             FileMapperOptions testMappingOptions = buildTestsOptions();
-
-            connection = DriverManager.getConnection(url, user, password);
+            OracleDataSource ds = new OracleDataSource();
+            ds.setURL(url);
+            ds.setUser(user);
+            ds.setPassword(password);
+            connection = ds.getConnection();
 
             Version utlVersion = DBHelper.getDatabaseFrameworkVersion(connection);
             getLog().info("utPLSQL Version = " + utlVersion);
@@ -173,6 +175,7 @@ public class UtPLSQLMojo extends AbstractMojo {
             try {
                 if (null != connection) {
                     reporterWriter.writeReporters(connection);
+                    connection.close();
                 }
             } catch (Exception e) {
                 getLog().error(e.getMessage(), e);


### PR DESCRIPTION
Addresses #23.

Swaps the `test` goal from using the DriverManager abstraction to a directly created DataSource to combat classloader issues when used in conjunction with other Maven plugins loading the `oracle.jdbc.driver.OracleDriver` such as the Liquibase Maven Plugin.

No option to set reviewers so @jgebal @pesse please.